### PR TITLE
Kevin/mysql connector

### DIFF
--- a/appdev/connectors/mysql_connector.py
+++ b/appdev/connectors/mysql_connector.py
@@ -1,0 +1,73 @@
+from threading import Thread
+from Queue import Queue
+import mysql.connector
+
+
+class DbThread(Thread):
+  def __init__(self, connection, cursor, table, data, queue=None):
+    super(DbThread, self).__init__()
+    self.connection = connection
+    self.cursor = cursor
+    self.table = table
+    self.data = data
+    self.queue = queue
+
+
+class WriterThread(DbThread):
+  def run(self):
+    # Create query in the format:
+    #   "INSERT INTO salaries (emp_no, salary, from_date, to_date)
+    #     VALUES (%(emp_no)s, %(salary)s, %(from_date)s, %(to_date)s)"
+    values_string = ['%({})s'.format(col) for col in self.data.keys()]
+    insert_query = "INSERT INTO {} ({}) VALUES ({})" \
+      .format(self.table, ', '.join(self.data.keys()), ', '.join(values_string))
+    self.cursor.execute(insert_query, self.data)
+    self.connection.commit()
+
+
+class ReaderThread(DbThread):
+  def run(self):
+    # data is (a, b) which indicates the inclusive range for this query
+    read_query = "SELECT * FROM {0} OFFSET {1} LIMIT {2} - {1} + 1" \
+                    .format(self.table, self.data[0], self.data[1])
+    self.cursor.execute(read_query)
+    return [_ for _ in self.cursor]
+
+
+class MySQLConnector(Object):
+  def __init__(self, user, password, host, database):
+    self.connection = mysql.connector.connect(user=user,
+                                              password=password,
+                                              host=host,
+                                              database=database)
+    self.cursor = self.connection.cursor()
+
+  def close(self):
+    self.connection.close()
+
+  def read_batch(self, table, start, end, num_workers):
+    threads = []
+    queue = Queue()
+    range_size = (end - start + 1) / num_workers
+    for i in num_workers:
+      a = range_size * i
+      b = a + range_size - 1
+      thread = ReaderThread(self.connection, self.cursor,
+                            table, (a, b), queue=queue)
+      thread.start()
+      threads.append(thread)
+    for thread in threads:
+      thread.join()
+    rows = []
+    while not queue.empty():
+      rows.extend(queue.get())
+    return rows
+
+  def write_batch(self, table, rows):
+    threads = []
+    for i in range(rows):
+      thread = WriterThread(self.connection, self.cursor, table, rows[i])
+      thread.start()
+      threads.append(thread)
+    for thread in threads:
+      thread.join()

--- a/appdev/connectors/mysql_connector.py
+++ b/appdev/connectors/mysql_connector.py
@@ -30,10 +30,10 @@ class WriterThread(DbThread):
         data = self.input_queue.get(timeout=self.queue_timeout)
       except Empty:
         break
-      values_string = ['%({})s'.format(col) for col in data.keys()]
+      placeholder_values_array = ['%({})s'.format(col) for col in data.keys()]
       insert_query = "INSERT INTO {} ({}) VALUES ({})" \
         .format(self.table, ', '.join(data.keys()),
-                ', '.join(values_string))
+                ', '.join(placeholder_values_array))
       cursor.execute(insert_query, data)
       connection.commit()
       self.input_queue.task_done()
@@ -84,8 +84,9 @@ class MySQLConnector(object):
   def scale_connection_pool(self, num_connections):
     """
       Alters the connection pool to have `num_connections` of connections in the
-      pool. Note `num_connections` must be a non-negative integer.
+      pool. Note `num_connections` must be a positive integer.
     """
+    assert num_connections > 0, "`num_connections` must be a positive integer"
     if self.num_connections < num_connections:
       # Scale up
       for _ in range(num_connections - self.num_connections):

--- a/appdev/connectors/mysql_connector.py
+++ b/appdev/connectors/mysql_connector.py
@@ -1,16 +1,17 @@
 from threading import Thread
-from Queue import Queue
+from Queue import Queue, Empty
 import mysql.connector
 
 
 class DbThread(Thread):
-  def __init__(self, connection, cursor, table, data, queue=None):
+  def __init__(self, connection_pool, table, input_queue, result_queue=None,
+               queue_timeout=0.5):
     super(DbThread, self).__init__()
-    self.connection = connection
-    self.cursor = cursor
+    self.connection_pool = connection_pool
     self.table = table
-    self.data = data
-    self.queue = queue
+    self.input_queue = input_queue
+    self.result_queue = result_queue
+    self.queue_timeout = queue_timeout
 
 
 class WriterThread(DbThread):
@@ -18,56 +19,87 @@ class WriterThread(DbThread):
     # Create query in the format:
     #   "INSERT INTO salaries (emp_no, salary, from_date, to_date)
     #     VALUES (%(emp_no)s, %(salary)s, %(from_date)s, %(to_date)s)"
-    values_string = ['%({})s'.format(col) for col in self.data.keys()]
-    insert_query = "INSERT INTO {} ({}) VALUES ({})" \
-      .format(self.table, ', '.join(self.data.keys()), ', '.join(values_string))
-    self.cursor.execute(insert_query, self.data)
-    self.connection.commit()
+    # data is dictionary such as {'emp_no': 1, 'salary': 2, ...}
+    while not self.input_queue.empty():
+      connection = self.connection_pool.get()
+      cursor = connection.cursor()
+      try:
+        # A thread may enter the loop, but another thread could pluck the
+        # last item. This timeout is to prevent a thread from waiting for
+        # another item that will never come.
+        data = self.input_queue.get(timeout=self.queue_timeout)
+      except Empty:
+        break
+      values_string = ['%({})s'.format(col) for col in data.keys()]
+      insert_query = "INSERT INTO {} ({}) VALUES ({})" \
+        .format(self.table, ', '.join(data.keys()),
+                ', '.join(values_string))
+      cursor.execute(insert_query, data)
+      connection.commit()
+      self.input_queue.task_done()
+      self.connection_pool.put(connection)
 
 
 class ReaderThread(DbThread):
   def run(self):
-    # data is (a, b) which indicates the inclusive range for this query
-    read_query = "SELECT * FROM {0} OFFSET {1} LIMIT {2} - {1} + 1" \
-                    .format(self.table, self.data[0], self.data[1])
-    self.cursor.execute(read_query)
-    return [_ for _ in self.cursor]
+    while not self.input_queue.empty():
+      connection = self.connection_pool.get()
+      cursor = connection.cursor()
+      try:
+        a, b = self.input_queue.get(timeout=self.queue_timeout)
+      except Empty:
+        break
+      read_query = "SELECT * FROM {} LIMIT {} OFFSET {}" \
+                     .format(self.table, b-a+1, a)
+      cursor.execute(read_query)
+      result = []
+      for row in cursor:
+        result.append(row)
+      self.input_queue.task_done()
+      self.result_queue.put(result)
+      self.connection_pool.put(connection)
 
 
-class MySQLConnector(Object):
-  def __init__(self, user, password, host, database):
-    self.connection = mysql.connector.connect(user=user,
-                                              password=password,
-                                              host=host,
-                                              database=database)
-    self.cursor = self.connection.cursor()
+class MySQLConnector(object):
+  def __init__(self, user, password, host, database,
+               num_connections=10, num_threads=10):
+    self.config = {
+        'user': user,
+        'password': password,
+        'host': host,
+        'database': database
+    }
+    self.connection_pool = Queue()
+    self.num_threads = num_threads
+    for _ in range(num_connections):
+      cnx = mysql.connector.connect(**self.config)
+      self.connection_pool.put(cnx)
 
   def close(self):
-    self.connection.close()
+    while not self.connection_pool.empty():
+      connection = self.connection_pool.get()
+      connection.close()
 
-  def read_batch(self, table, start, end, num_workers):
-    threads = []
-    queue = Queue()
-    range_size = (end - start + 1) / num_workers
-    for i in num_workers:
-      a = range_size * i
-      b = a + range_size - 1
-      thread = ReaderThread(self.connection, self.cursor,
-                            table, (a, b), queue=queue)
-      thread.start()
-      threads.append(thread)
-    for thread in threads:
-      thread.join()
+  def read_batch(self, table, start, end, interval_size=10):
+    input_queue = Queue()
+    result_queue = Queue()
+    a = start
+    while a <= end:
+      input_queue.put((a, a + interval_size))
+      a += interval_size
+    for _ in range(self.num_threads):
+      ReaderThread(self.connection_pool, table, input_queue,
+                   result_queue=result_queue).start()
+    input_queue.join()
     rows = []
-    while not queue.empty():
-      rows.extend(queue.get())
+    while not result_queue.empty():
+      rows.extend(result_queue.get())
     return rows
 
   def write_batch(self, table, rows):
-    threads = []
-    for i in range(rows):
-      thread = WriterThread(self.connection, self.cursor, table, rows[i])
-      thread.start()
-      threads.append(thread)
-    for thread in threads:
-      thread.join()
+    input_queue = Queue()
+    for row in rows:
+      input_queue.put(row)
+    for _ in range(self.num_threads):
+      WriterThread(self.connection_pool, table, input_queue).start()
+    input_queue.join()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Jinja2==2.9.6
 MarkupSafe==1.0
 nose==1.3.7
 Werkzeug==0.12.2
+mysql-connector==2.1.4

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     package_data={'': ['README.rst']},
     install_requires=[
         'Flask',
+        'mysql-connector',
     ],
     tests_require=[],
     classifiers=[


### PR DESCRIPTION
I hand tested this by calling the `write_batch` and `read_batch` functions while connected to a test database and ensuring the calls returned the correct info / added the correct rows. 

The default numbers for `num_connections`, `num_threads`, `interval_size`, and `queue_timeout` are all arbitrary, let me know if you think other default values would be better. 