### PR TITLE
include mysql-connector version in setup.py, include classes in appde…

### DIFF
--- a/appdev/connectors/__init__.py
+++ b/appdev/connectors/__init__.py
@@ -1,0 +1,2 @@
+from mysql_connector import MySQLConnector
+from redis_connector import RedisConnector

--- a/appdev/connectors/redis_connector.py
+++ b/appdev/connectors/redis_connector.py
@@ -2,9 +2,9 @@ import redis
 import numpy as np
 
 
-class RedisConn(object):
+class RedisConnector(object):
   """
-    RedisConn object creates a connector to an already running Redis instance.
+    RedisConnector object creates a connector to an already running Redis instance.
     Parameters:
         name (str): Naming the specific connection
         host (str): The host which we are connecting to. This is typically
@@ -18,12 +18,12 @@ class RedisConn(object):
     _single_connect(self):
           Returns a single connection that you can execute commands on
           Example:
-            redis = RedisConn(...)
+            redis = RedisConnector(...)
             connection = redis._single_connect()
     _connect_pool(self):
           Spawns a connection pool that you can pull connections from
           Example:
-            redis = RedisConn(...)
+            redis = RedisConnector(...)
             connection_pool = redis._connection_pool()
             connection = connection_pool.get_connection()
             connection.send_command(*args)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'': ['README.rst']},
     install_requires=[
         'Flask',
-        'mysql-connector',
+        'mysql-connector==2.1.4',
         'redis'
     ],
     tests_require=[],


### PR DESCRIPTION
I ran into some trouble when tried to update my appdev.py with pip, then I remembered I had to include the version of mysql-connector in requirements.txt to get everything working. Since I didn't also include the version in setup.py, I was getting errors.

In this PR I also import both connectors in appdev.controllers and rename RedisConn to RedisConnector for both connectors to have a similar naming scheme.