### PR TITLE
Add to requirements.txt and make result rows dictionaries

### DIFF
--- a/appdev/connectors/mysql_connector.py
+++ b/appdev/connectors/mysql_connector.py
@@ -52,7 +52,7 @@ class ReaderThread(DbThread):
   def run(self):
     while not self.input_queue.empty():
       connection = self.connection_pool.get()
-      cursor = connection.cursor()
+      cursor = connection.cursor(dictionary=True)
       try:
         query = self.input_queue.get(timeout=self.queue_timeout)
       except Empty:

--- a/hand_tests.py
+++ b/hand_tests.py
@@ -1,0 +1,14 @@
+from appdev.connectors.mysql_connector import MySQLConnector
+
+def test_mysql():
+  TEST_USERNAME = 'TODO'
+  TEST_PASSWORD = 'TODO'
+  TEST_HOST = 'TODO'
+  TEST_DB_NAME = 'TODO'
+  connector = MySQLConnector(TEST_USERNAME, TEST_PASSWORD, \
+    TEST_HOST, TEST_DB_NAME)
+  rows = connector.read_batch('TODO', interval_size=1000)
+  print rows
+
+if __name__ == '__main__':
+  test_mysql()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ lazy-object-proxy==1.3.1
 MarkupSafe==1.0
 mccabe==0.6.1
 mysql==0.0.1
+mysql-connector-python-rf==2.2.2
 MySQL-python==1.2.5
 nose==1.3.7
 numpy==1.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ Jinja2==2.9.6
 lazy-object-proxy==1.3.1
 MarkupSafe==1.0
 mccabe==0.6.1
+mysql==0.0.1
+MySQL-python==1.2.5
 nose==1.3.7
 numpy==1.13.3
 pycodestyle==2.3.1


### PR DESCRIPTION
Makes the result rows of a query via the MySQL connection dictionaries of the form:
```javascript
{
  column1: 'value1',
  column2: 'value2',
 // etc.
}
```

Also updates `requirements.txt`, as it was out of date from what I saw.